### PR TITLE
FIX: hover over dropdown navbar element now removes focus from other dropdown

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+// 
+
 // Reset dropdowns and manage focus on resize
 function resetDropdownsOnResize() {
   const allDropdowns = document.querySelectorAll(".nav__menu .dropdown");
@@ -95,6 +97,31 @@ Array.from(dropdown).map((element) => {
     e.stopPropagation();
   });
 });
+
+// Add hover event handlers for desktop view
+document.querySelectorAll('.nav__menu .dropdown').forEach(dropdown => {
+  dropdown.addEventListener('mouseenter', () => {
+    if (window.innerWidth >= 768) {
+      const allDropdowns = document.querySelectorAll('.nav__menu .dropdown');
+      allDropdowns.forEach(otherDropdown => {
+        if (otherDropdown !== dropdown) {
+          const otherDropdownMenu = otherDropdown.querySelector('ul');
+          if (otherDropdownMenu) {
+            otherDropdownMenu.classList.remove('show');
+            otherDropdown.classList.remove('active', 'focus');
+          }
+        }
+      });
+
+      const dropdownMenu = dropdown.querySelector('ul');
+      if (dropdownMenu && !dropdownMenu.classList.contains('show')) {
+        dropdownMenu.classList.add('show');
+        dropdown.classList.add('active');
+      }
+    }
+  });
+});
+
 
 // Open dropdown on link focus (solve invisible tabbing issue)
 


### PR DESCRIPTION
**Previous behaviour**: after navigating in mobile view, the window would autofocus on the first dropdown element in the navbar following a resize event to desktop view. The focus would remain intact once the user would hover over another navbar dropdown element, which is undesirable from both an accessibility and a UX standpoint.

**Corrected behaviour**: Following a resize event, the navigation autofocuses on the first element in the navbar still, but when the user hovers over a different navbar element, the focus is placed onto that element.